### PR TITLE
add katana to player + couple of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 [Aa]ssets/Thirdparty/
 [Aa]ssets/TextMesh Pro/
 
+.editorconfig
+.vsconfig
+.config/
+.vscode/
+
+
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data
 [Mm]emoryCaptures/

--- a/Assets/Materials/Prototype_512x512_Blue2.mat
+++ b/Assets/Materials/Prototype_512x512_Blue2.mat
@@ -1,22 +1,29 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3316996563839529924
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
 --- !u!21 &2100000
 Material:
-  serializedVersion: 8
+  serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Prototype_512x512_Blue3
+  m_Name: Prototype_512x512_Blue2
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords:
-  - _NORMALMAP
-  - _SPECULARHIGHLIGHTS_OFF
-  m_InvalidKeywords:
-  - _DISABLE_SSR_TRANSPARENT
-  - _NORMALMAP_TANGENT_SPACE
+  m_ShaderKeywords: _DISABLE_SSR_TRANSPARENT _NORMALMAP _NORMALMAP_TANGENT_SPACE
+    _SPECULARHIGHLIGHTS_OFF
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -29,7 +36,6 @@ Material:
   - TransparentDepthPostpass
   - TransparentBackface
   - RayTracingPrepass
-  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -38,11 +44,11 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BaseColorMap:
-        m_Texture: {fileID: 2800000, guid: b6fc60785b6a795478135ce6f7712c5a, type: 3}
+        m_Texture: {fileID: 2800000, guid: 17198718c5735204999fb13dc36e290f, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BaseMap:
-        m_Texture: {fileID: 2800000, guid: b6fc60785b6a795478135ce6f7712c5a, type: 3}
+        m_Texture: {fileID: 2800000, guid: 17198718c5735204999fb13dc36e290f, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BentNormalMap:
@@ -102,7 +108,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: b6fc60785b6a795478135ce6f7712c5a, type: 3}
+        m_Texture: {fileID: 2800000, guid: 17198718c5735204999fb13dc36e290f, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MaskMap:
@@ -169,7 +175,6 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    m_Ints: []
     m_Floats:
     - _AORemapMax: 1
     - _AORemapMin: 0
@@ -337,7 +342,7 @@ Material:
     - _UVMappingMask: {r: 1, g: 0, b: 0, a: 0}
     - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
---- !u!114 &405463733965869680
+--- !u!114 &401755358572647137
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}
@@ -350,16 +355,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   version: 11
---- !u!114 &4270820687507988644
-MonoBehaviour:
-  m_ObjectHideFlags: 11
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  version: 1

--- a/Assets/Materials/Prototype_512x512_Blue2.mat.meta
+++ b/Assets/Materials/Prototype_512x512_Blue2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 349eb9bb273627f0391f65ec3f970c65
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Prototype_512x512_Blue3.mat.meta
+++ b/Assets/Materials/Prototype_512x512_Blue3.mat.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ec3eb1a1d5f61504190ae66512590463
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 2100000
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Prototype.unity
+++ b/Assets/Prototype.unity
@@ -426,7 +426,7 @@ MonoBehaviour:
   dragSmoothMultiplier: 7000
   body: {fileID: 0}
   orientation: {fileID: 1965360236}
-  yOrientation: {fileID: 0}
+  yOrientation: {fileID: 1420223656}
   moveDirection: {x: 0, y: 0, z: 0}
   speed: 8000
   moveSpeed: 8000
@@ -1805,7 +1805,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1611379868}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.35}
   m_LocalScale: {x: 0.6, y: 0.2, z: 0.5}
   m_ConstrainProportionsScale: 0
@@ -2350,7 +2350,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cam: {fileID: 963194227}
   orientation: {fileID: 1965360236}
-  yOrientation: {fileID: 0}
+  yOrientation: {fileID: 1420223656}
   sensitivity: 100
 --- !u!1 &1912256165
 GameObject:

--- a/Assets/Prototype.unity
+++ b/Assets/Prototype.unity
@@ -227,6 +227,11 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 26804520}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &41592336 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+  m_PrefabInstance: {fileID: 1563246008}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &81566784
 GameObject:
   m_ObjectHideFlags: 0
@@ -509,6 +514,9 @@ MonoBehaviour:
   grounded: 0
   jumping: 0
   crouching: 0
+  objectsToNotGetScaledWhenCrouching:
+  - {fileID: 505998464}
+  - {fileID: 1611379869}
   slopeMoveDirection: {x: 0, y: 0, z: 0}
 --- !u!114 &393385516
 MonoBehaviour:
@@ -530,6 +538,20 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
   m_PrefabInstance: {fileID: 1563246008}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &505998465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41592336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 20a0025fffa0bbfe8b7403e7b03b9d63, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  smooth: 8
+  swayMultiplier: 4
 --- !u!1 &609968318
 GameObject:
   m_ObjectHideFlags: 0
@@ -951,7 +973,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1181029832}
   m_Father: {fileID: 1894180742}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1033701264
@@ -1175,8 +1198,7 @@ GameObject:
   - component: {fileID: 1181029832}
   - component: {fileID: 1181029835}
   - component: {fileID: 1181029834}
-  - component: {fileID: 1181029833}
-  m_Layer: 6
+  m_Layer: 0
   m_Name: Hand
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1191,35 +1213,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1181029831}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5500002, y: 0, z: 0.25}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.5500002, y: -0.5, z: 0.35}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 505998464}
-  m_Father: {fileID: 1965360236}
-  m_LocalEulerAnglesHint: {x: -0, y: 0, z: 0}
---- !u!135 &1181029833
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1181029831}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Father: {fileID: 963194228}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1181029834
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1626,7 +1627,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 505998465}
   m_SourcePrefab: {fileID: 100100000, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
 --- !u!1 &1611379868
 GameObject:
@@ -2201,6 +2205,7 @@ MonoBehaviour:
   cam: {fileID: 0}
   cameraPosition: {fileID: 1382896929}
   orientation: {fileID: 1965360236}
+  hand: {fileID: 1181029832}
   sensitivity: 80
 --- !u!1 &1912256165
 GameObject:
@@ -2337,7 +2342,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1611379869}
-  - {fileID: 1181029832}
   m_Father: {fileID: 393385510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2036548697

--- a/Assets/Prototype.unity
+++ b/Assets/Prototype.unity
@@ -401,6 +401,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1420223656}
   - {fileID: 1965360236}
   - {fileID: 1894180742}
   - {fileID: 1389112131}
@@ -423,8 +424,9 @@ MonoBehaviour:
   crouchDrag: 20
   airDrag: 7
   dragSmoothMultiplier: 7000
-  body: {fileID: 1389112131}
+  body: {fileID: 0}
   orientation: {fileID: 1965360236}
+  yOrientation: {fileID: 0}
   moveDirection: {x: 0, y: 0, z: 0}
   speed: 8000
   moveSpeed: 8000
@@ -502,6 +504,7 @@ MonoBehaviour:
   cam: {fileID: 1894180742}
   cameraPosition: {fileID: 1382896929}
   orientation: {fileID: 1965360236}
+  yOrientation: {fileID: 1420223656}
   orientationPosition: {fileID: 1297095630}
   feet: {fileID: 845353974}
   feetPosition: {fileID: 377939366}
@@ -1184,9 +1187,9 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1181029831}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.258819, y: 0, z: 0, w: 0.9659259}
-  m_LocalPosition: {x: -0.5500002, y: 0, z: 0.25}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalRotation: {x: -0.258819, y: -0, z: -0, w: 0.9659259}
+  m_LocalPosition: {x: -0.5500002, y: -0.5, z: 0.25}
+  m_LocalScale: {x: 0.1, y: 0.10000002, z: 0.10000002}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 505998464}
@@ -1267,7 +1270,7 @@ Transform:
   m_GameObject: {fileID: 1297095629}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1517,6 +1520,37 @@ Transform:
   - {fileID: 1382896929}
   - {fileID: 1297095630}
   - {fileID: 377939366}
+  m_Father: {fileID: 393385510}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1420223655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1420223656}
+  m_Layer: 0
+  m_Name: YOrientation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1420223656
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1420223655}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
   m_Father: {fileID: 393385510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1434422979
@@ -1771,8 +1805,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1611379868}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0.3}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.35}
   m_LocalScale: {x: 0.6, y: 0.2, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2314,9 +2348,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f34beb232a4efcc4eaeec59d9ba58e0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cam: {fileID: 0}
+  cam: {fileID: 963194227}
   orientation: {fileID: 1965360236}
-  sensitivity: 80
+  yOrientation: {fileID: 0}
+  sensitivity: 100
 --- !u!1 &1912256165
 GameObject:
   m_ObjectHideFlags: 0
@@ -2446,14 +2481,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1965360235}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1611379869}
-  - {fileID: 1181029832}
   - {fileID: 845353974}
+  - {fileID: 1181029832}
   m_Father: {fileID: 393385510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2036548697

--- a/Assets/Prototype.unity
+++ b/Assets/Prototype.unity
@@ -347,7 +347,7 @@ GameObject:
   - component: {fileID: 393385511}
   - component: {fileID: 393385515}
   - component: {fileID: 393385516}
-  m_Layer: 6
+  m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -525,6 +525,11 @@ MonoBehaviour:
   rb: {fileID: 393385511}
   velocityUpdateInterval: 1
   velocityText: {fileID: 2138165420}
+--- !u!4 &505998464 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+  m_PrefabInstance: {fileID: 1563246008}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &609968318
 GameObject:
   m_ObjectHideFlags: 0
@@ -781,7 +786,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: ec3eb1a1d5f61504190ae66512590463, type: 2}
+  - {fileID: 2100000, guid: 349eb9bb273627f0391f65ec3f970c65, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1159,6 +1164,112 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1171308212}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1181029831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1181029832}
+  - component: {fileID: 1181029835}
+  - component: {fileID: 1181029834}
+  - component: {fileID: 1181029833}
+  m_Layer: 6
+  m_Name: Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1181029832
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1181029831}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.5500002, y: 0, z: 0.25}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 505998464}
+  m_Father: {fileID: 1965360236}
+  m_LocalEulerAnglesHint: {x: -0, y: 0, z: 0}
+--- !u!135 &1181029833
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1181029831}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1181029834
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1181029831}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1181029835
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1181029831}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1375231791
 GameObject:
   m_ObjectHideFlags: 0
@@ -1450,27 +1561,39 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1181029832}
     m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.401
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.9659259
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0.258819
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalRotation.y
@@ -1482,7 +1605,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -30
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -1491,6 +1614,10 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_Name
@@ -2052,7 +2179,7 @@ Transform:
   m_GameObject: {fileID: 1894180741}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2210,6 +2337,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1611379869}
+  - {fileID: 1181029832}
   m_Father: {fileID: 393385510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2036548697
@@ -2526,6 +2654,5 @@ SceneRoots:
   - {fileID: 705507995}
   - {fileID: 1470263716}
   - {fileID: 393385510}
-  - {fileID: 1563246008}
   - {fileID: 609968322}
   - {fileID: 2036548700}

--- a/Assets/Prototype.unity
+++ b/Assets/Prototype.unity
@@ -337,6 +337,37 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 81566784}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &377939365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 377939366}
+  m_Layer: 0
+  m_Name: FeetPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &377939366
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 377939365}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.9, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389112131}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &393385509
 GameObject:
   m_ObjectHideFlags: 0
@@ -346,12 +377,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 393385510}
-  - component: {fileID: 393385514}
-  - component: {fileID: 393385513}
-  - component: {fileID: 393385512}
-  - component: {fileID: 393385511}
+  - component: {fileID: 393385517}
   - component: {fileID: 393385515}
   - component: {fileID: 393385516}
+  - component: {fileID: 393385518}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -372,13 +401,66 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1382896929}
   - {fileID: 1965360236}
-  - {fileID: 845353974}
   - {fileID: 1894180742}
+  - {fileID: 1389112131}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &393385511
+--- !u!114 &393385515
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 393385509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 991d270881240be4fbfefc92d513eebf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerScale: {x: 1, y: 1, z: 1}
+  playerDrag: 14
+  crouchDrag: 20
+  airDrag: 7
+  dragSmoothMultiplier: 7000
+  body: {fileID: 1389112131}
+  orientation: {fileID: 1965360236}
+  moveDirection: {x: 0, y: 0, z: 0}
+  speed: 8000
+  moveSpeed: 8000
+  fallMultiplier: 3000
+  airMultiplier: 0.52
+  crouchAirMultiplier: 0.2
+  jumpForce: 1000
+  crouchJumpMultiplier: 0.65
+  crouchScale: {x: 1, y: 0.7, z: 1}
+  crouchTopSpeed: 13000
+  crouchSpeed: 5000
+  feet: {fileID: 845353974}
+  groundCheckBox: {x: 0.3, y: 0.105, z: 0.3}
+  groundLayer:
+    serializedVersion: 2
+    m_Bits: 128
+  grounded: 0
+  jumping: 0
+  crouching: 0
+  slopeMoveDirection: {x: 0, y: 0, z: 0}
+--- !u!114 &393385516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 393385509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4ab77be94b091a46add91c165f17644, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rb: {fileID: 393385517}
+  velocityUpdateInterval: 1
+  velocityText: {fileID: 2138165420}
+--- !u!54 &393385517
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -402,83 +484,10 @@ Rigidbody:
   m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 112
   m_CollisionDetection: 3
---- !u!136 &393385512
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393385509}
-  m_Material: {fileID: 13400000, guid: 149ac39af45afc444a610b41660a47c0, type: 2}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &393385513
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393385509}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &393385514
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393385509}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!114 &393385515
+--- !u!114 &393385518
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -487,52 +496,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 393385509}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 991d270881240be4fbfefc92d513eebf, type: 3}
+  m_Script: {fileID: 11500000, guid: 8fe11ebc6784b938fab7770fff3e297f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerScale: {x: 1, y: 1, z: 1}
-  playerDrag: 14
-  crouchDrag: 20
-  airDrag: 7
-  dragSmoothMultiplier: 7000
+  cam: {fileID: 1894180742}
+  cameraPosition: {fileID: 1382896929}
   orientation: {fileID: 1965360236}
-  moveDirection: {x: 0, y: 0, z: 0}
-  speed: 8000
-  moveSpeed: 8000
-  fallMultiplier: 3000
-  airMultiplier: 0.52
-  crouchAirMultiplier: 0.2
-  jumpForce: 1000
-  crouchJumpMultiplier: 0.65
-  crouchTopSpeed: 13000
-  crouchSpeed: 5000
+  orientationPosition: {fileID: 1297095630}
   feet: {fileID: 845353974}
-  groundCheckBox: {x: 0.3, y: 0.105, z: 0.3}
-  groundLayer:
-    serializedVersion: 2
-    m_Bits: 128
-  grounded: 0
-  jumping: 0
-  crouching: 0
-  objectsToNotGetScaledWhenCrouching:
-  - {fileID: 505998464}
-  - {fileID: 1611379869}
-  slopeMoveDirection: {x: 0, y: 0, z: 0}
---- !u!114 &393385516
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393385509}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a4ab77be94b091a46add91c165f17644, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rb: {fileID: 393385511}
-  velocityUpdateInterval: 1
-  velocityText: {fileID: 2138165420}
+  feetPosition: {fileID: 377939366}
 --- !u!4 &505998464 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
@@ -551,7 +523,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   smooth: 8
-  swayMultiplier: 4
+  swayMultiplier: 3
 --- !u!1 &609968318
 GameObject:
   m_ObjectHideFlags: 0
@@ -877,12 +849,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 845353973}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.9, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.9000001, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 393385510}
+  m_Father: {fileID: 1965360236}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
 GameObject:
@@ -973,8 +945,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1181029832}
+  m_Children: []
   m_Father: {fileID: 1894180742}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1033701264
@@ -1213,14 +1184,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1181029831}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.5500002, y: -0.5, z: 0.35}
+  m_LocalRotation: {x: -0.258819, y: 0, z: 0, w: 0.9659259}
+  m_LocalPosition: {x: -0.5500002, y: 0, z: 0.25}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 505998464}
-  m_Father: {fileID: 963194228}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Father: {fileID: 1965360236}
+  m_LocalEulerAnglesHint: {x: -30, y: 0, z: 0}
 --- !u!23 &1181029834
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1271,6 +1242,37 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1181029831}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1297095629
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1297095630}
+  m_Layer: 0
+  m_Name: OrientationPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1297095630
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297095629}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389112131}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1375231791
 GameObject:
   m_ObjectHideFlags: 0
@@ -1400,11 +1402,121 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1382896928}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
+  m_Father: {fileID: 1389112131}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1389112126
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1389112131}
+  - component: {fileID: 1389112130}
+  - component: {fileID: 1389112129}
+  - component: {fileID: 1389112128}
+  m_Layer: 0
+  m_Name: Body
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1389112128
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389112126}
+  m_Material: {fileID: 13400000, guid: 149ac39af45afc444a610b41660a47c0, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1389112129
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389112126}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1389112130
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389112126}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1389112131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389112126}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1382896929}
+  - {fileID: 1297095630}
+  - {fileID: 377939366}
   m_Father: {fileID: 393385510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1434422979
@@ -1590,11 +1702,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9659259
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.258819
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalRotation.y
@@ -1606,7 +1718,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -30
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9f148be765531624b95ccf0c7e04e524, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -2203,9 +2315,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cam: {fileID: 0}
-  cameraPosition: {fileID: 1382896929}
   orientation: {fileID: 1965360236}
-  hand: {fileID: 1181029832}
   sensitivity: 80
 --- !u!1 &1912256165
 GameObject:
@@ -2342,6 +2452,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1611379869}
+  - {fileID: 1181029832}
+  - {fileID: 845353974}
   m_Father: {fileID: 393385510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2036548697

--- a/Assets/Scripts/AdvancedGizmosVisualizer.cs
+++ b/Assets/Scripts/AdvancedGizmosVisualizer.cs
@@ -4,83 +4,96 @@ using UnityEngine;
 
 // CREDITS GO TO: https://youtu.be/I1zKmIPT92U?si=FuA8I3eYNMQxDjLJ
 
-public class AdvancedGizmosVisualizer : MonoBehaviour {
-    public static void DisplayBox(Vector3 center, Vector3 HalfExtend, Quaternion rotation, float Duration = 0) {
-        Vector3[] Vertices = new Vector3[8];
-        int i = 0;
-        for (int x = -1; x < 2; x += 2) {
-            for (int y = -1; y < 2; y += 2) {
-                for (int z = -1; z < 2; z += 2) {
-                    Vertices[i] = center + new Vector3(HalfExtend.x * x, HalfExtend.y * y, HalfExtend.z * z);
-                    i++;
-                }
-            }
-        }
-
-        Vertices = RotateObject(Vertices, rotation.eulerAngles, center);
-
-        Debug.DrawLine(Vertices[0], Vertices[1], Color.white, Duration);
-        Debug.DrawLine(Vertices[1], Vertices[3], Color.white, Duration);
-        Debug.DrawLine(Vertices[2], Vertices[3], Color.white, Duration);
-        Debug.DrawLine(Vertices[2], Vertices[0], Color.white, Duration);
-        Debug.DrawLine(Vertices[4], Vertices[0], Color.white, Duration);
-        Debug.DrawLine(Vertices[4], Vertices[6], Color.white, Duration);
-        Debug.DrawLine(Vertices[2], Vertices[6], Color.white, Duration);
-        Debug.DrawLine(Vertices[7], Vertices[6], Color.white, Duration);
-        Debug.DrawLine(Vertices[7], Vertices[3], Color.white, Duration);
-        Debug.DrawLine(Vertices[7], Vertices[5], Color.white, Duration);
-        Debug.DrawLine(Vertices[1], Vertices[5], Color.white, Duration);
-        Debug.DrawLine(Vertices[4], Vertices[5], Color.white, Duration);
-    }
-
-    static Vector3[] RotateObject(Vector3[] ObjToRotate, Vector3 DegreesToRotate, Vector3 Around)//rotates a set of dots counterclockwise
+public class AdvancedGizmosVisualizer : MonoBehaviour
+{
+  public static void DisplayBox(Vector3 center, Vector3 HalfExtend, Quaternion rotation, float Duration = 0)
+  {
+    Vector3[] Vertices = new Vector3[8];
+    int i = 0;
+    for (int x = -1; x < 2; x += 2)
     {
-        for (int i = 0; i < ObjToRotate.Length; i++) {
-            ObjToRotate[i] -= Around;
+      for (int y = -1; y < 2; y += 2)
+      {
+        for (int z = -1; z < 2; z += 2)
+        {
+          Vertices[i] = center + new Vector3(HalfExtend.x * x, HalfExtend.y * y, HalfExtend.z * z);
+          i++;
         }
-        DegreesToRotate.z = Mathf.Deg2Rad * DegreesToRotate.z;
-        DegreesToRotate.x = Mathf.Deg2Rad * DegreesToRotate.x;
-        DegreesToRotate.y = -Mathf.Deg2Rad * DegreesToRotate.y;
-
-        for (int i = 0; i < ObjToRotate.Length; i++) {
-            float H = Vector3.Distance(Vector3.zero, ObjToRotate[i]);
-            if (H != 0) {
-                float CosA = ObjToRotate[i].x / H;
-                float SinA = ObjToRotate[i].y / H;
-                float cosB = Mathf.Cos(DegreesToRotate.z);
-                float SinB = Mathf.Sin(DegreesToRotate.z);
-                ObjToRotate[i] = new Vector3(H * (CosA * cosB - SinA * SinB), H * (SinA * cosB + CosA * SinB), ObjToRotate[i].z);
-            }
-        }
-
-        for (int i = 0; i < ObjToRotate.Length; i++) {
-            float H = Vector3.Distance(Vector3.zero, ObjToRotate[i]);
-            if (H != 0) {
-                float CosA = ObjToRotate[i].y / H;
-                float SinA = ObjToRotate[i].z / H;
-                float cosB = Mathf.Cos(DegreesToRotate.x);
-                float SinB = Mathf.Sin(DegreesToRotate.x);
-                ObjToRotate[i] = new Vector3(ObjToRotate[i].x, H * (CosA * cosB - SinA * SinB), H * (SinA * cosB + CosA * SinB));
-            }
-        }
-
-        for (int i = 0; i < ObjToRotate.Length; i++) {
-            float H = Vector3.Distance(Vector3.zero, ObjToRotate[i]);
-            if (H != 0) {
-                float CosA = ObjToRotate[i].x / H;
-                float SinA = ObjToRotate[i].z / H;
-                float cosB = Mathf.Cos(DegreesToRotate.y);
-                float SinB = Mathf.Sin(DegreesToRotate.y);
-                ObjToRotate[i] = new Vector3((CosA * cosB - SinA * SinB) * H, ObjToRotate[i].y, H * (SinA * cosB + CosA * SinB));
-            }
-        }
-
-        for (int i = 0; i < ObjToRotate.Length; i++) {
-            ObjToRotate[i] += Around;
-        }
-
-
-
-        return ObjToRotate;
+      }
     }
+
+    Vertices = RotateObject(Vertices, rotation.eulerAngles, center);
+
+    Debug.DrawLine(Vertices[0], Vertices[1], Color.white, Duration);
+    Debug.DrawLine(Vertices[1], Vertices[3], Color.white, Duration);
+    Debug.DrawLine(Vertices[2], Vertices[3], Color.white, Duration);
+    Debug.DrawLine(Vertices[2], Vertices[0], Color.white, Duration);
+    Debug.DrawLine(Vertices[4], Vertices[0], Color.white, Duration);
+    Debug.DrawLine(Vertices[4], Vertices[6], Color.white, Duration);
+    Debug.DrawLine(Vertices[2], Vertices[6], Color.white, Duration);
+    Debug.DrawLine(Vertices[7], Vertices[6], Color.white, Duration);
+    Debug.DrawLine(Vertices[7], Vertices[3], Color.white, Duration);
+    Debug.DrawLine(Vertices[7], Vertices[5], Color.white, Duration);
+    Debug.DrawLine(Vertices[1], Vertices[5], Color.white, Duration);
+    Debug.DrawLine(Vertices[4], Vertices[5], Color.white, Duration);
+  }
+
+  static Vector3[] RotateObject(Vector3[] ObjToRotate, Vector3 DegreesToRotate, Vector3 Around)//rotates a set of dots counterclockwise
+  {
+    for (int i = 0; i < ObjToRotate.Length; i++)
+    {
+      ObjToRotate[i] -= Around;
+    }
+    DegreesToRotate.z = Mathf.Deg2Rad * DegreesToRotate.z;
+    DegreesToRotate.x = Mathf.Deg2Rad * DegreesToRotate.x;
+    DegreesToRotate.y = -Mathf.Deg2Rad * DegreesToRotate.y;
+
+    for (int i = 0; i < ObjToRotate.Length; i++)
+    {
+      float H = Vector3.Distance(Vector3.zero, ObjToRotate[i]);
+      if (H != 0)
+      {
+        float CosA = ObjToRotate[i].x / H;
+        float SinA = ObjToRotate[i].y / H;
+        float cosB = Mathf.Cos(DegreesToRotate.z);
+        float SinB = Mathf.Sin(DegreesToRotate.z);
+        ObjToRotate[i] = new Vector3(H * (CosA * cosB - SinA * SinB), H * (SinA * cosB + CosA * SinB), ObjToRotate[i].z);
+      }
+    }
+
+    for (int i = 0; i < ObjToRotate.Length; i++)
+    {
+      float H = Vector3.Distance(Vector3.zero, ObjToRotate[i]);
+      if (H != 0)
+      {
+        float CosA = ObjToRotate[i].y / H;
+        float SinA = ObjToRotate[i].z / H;
+        float cosB = Mathf.Cos(DegreesToRotate.x);
+        float SinB = Mathf.Sin(DegreesToRotate.x);
+        ObjToRotate[i] = new Vector3(ObjToRotate[i].x, H * (CosA * cosB - SinA * SinB), H * (SinA * cosB + CosA * SinB));
+      }
+    }
+
+    for (int i = 0; i < ObjToRotate.Length; i++)
+    {
+      float H = Vector3.Distance(Vector3.zero, ObjToRotate[i]);
+      if (H != 0)
+      {
+        float CosA = ObjToRotate[i].x / H;
+        float SinA = ObjToRotate[i].z / H;
+        float cosB = Mathf.Cos(DegreesToRotate.y);
+        float SinB = Mathf.Sin(DegreesToRotate.y);
+        ObjToRotate[i] = new Vector3((CosA * cosB - SinA * SinB) * H, ObjToRotate[i].y, H * (SinA * cosB + CosA * SinB));
+      }
+    }
+
+    for (int i = 0; i < ObjToRotate.Length; i++)
+    {
+      ObjToRotate[i] += Around;
+    }
+
+
+
+    return ObjToRotate;
+  }
 }

--- a/Assets/Scripts/AverageVelocityForRb.cs
+++ b/Assets/Scripts/AverageVelocityForRb.cs
@@ -4,40 +4,45 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-public class AverageVelocityForRb : MonoBehaviour {
-    public Rigidbody rb;
-    public float velocityUpdateInterval = 1f;
-    public TextMeshProUGUI velocityText;
+public class AverageVelocityForRb : MonoBehaviour
+{
+  public Rigidbody rb;
+  public float velocityUpdateInterval = 1f;
+  public TextMeshProUGUI velocityText;
 
-    private Queue<Vector3> positions = new Queue<Vector3>();
-    private Queue<float> timestamps = new Queue<float>();
+  private Queue<Vector3> positions = new Queue<Vector3>();
+  private Queue<float> timestamps = new Queue<float>();
 
-    // Update is called once per frame
-    void Update() {
-        CalculateAverageVelocity();
+  // Update is called once per frame
+  void Update()
+  {
+    CalculateAverageVelocity();
+  }
+
+  void CalculateAverageVelocity()
+  { // made by chatgpt 4o
+    // Record the current position and time
+    positions.Enqueue(rb.position);
+    timestamps.Enqueue(Time.time);
+
+    // Remove old data points that are outside the time window
+    while (timestamps.Count > 0 && Time.time - timestamps.Peek() > velocityUpdateInterval)
+    {
+      positions.Dequeue();
+      timestamps.Dequeue();
     }
 
-    void CalculateAverageVelocity() { // made by chatgpt 4o
-        // Record the current position and time
-        positions.Enqueue(rb.position);
-        timestamps.Enqueue(Time.time);
+    // Calculate the displacement over the time window
+    if (positions.Count > 1)
+    {
+      Vector3 displacement = rb.position - positions.Peek();
+      float timeElapsed = Time.time - timestamps.Peek();
 
-        // Remove old data points that are outside the time window
-        while (timestamps.Count > 0 && Time.time - timestamps.Peek() > velocityUpdateInterval) {
-            positions.Dequeue();
-            timestamps.Dequeue();
-        }
+      // Calculate average velocity
+      Vector3 averageVelocity = displacement / timeElapsed;
 
-        // Calculate the displacement over the time window
-        if (positions.Count > 1) {
-            Vector3 displacement = rb.position - positions.Peek();
-            float timeElapsed = Time.time - timestamps.Peek();
-
-            // Calculate average velocity
-            Vector3 averageVelocity = displacement / timeElapsed;
-
-            // Debug log to see the result
-            velocityText.text = ((int) averageVelocity.magnitude).ToString();
-        }
+      // Debug log to see the result
+      velocityText.text = ((int)averageVelocity.magnitude).ToString();
     }
+  }
 }

--- a/Assets/Scripts/CameraHandler.cs
+++ b/Assets/Scripts/CameraHandler.cs
@@ -4,37 +4,37 @@ using UnityEngine;
 
 public class CameraHandler : MonoBehaviour
 {
-    [Header("Camera")]
-    public Camera cam;
-    public Transform cameraPosition;
-    public Transform orientation;
-    public float sensitivity = 100f;
+  [Header("Camera")]
+  public Camera cam;
+  public Transform cameraPosition;
+  public Transform orientation;
+  public float sensitivity = 100f;
 
-    // Start is called before the first frame update
-    void Start()
-    {
-        Cursor.lockState = CursorLockMode.Locked;
-        Cursor.visible = false;
+  // Start is called before the first frame update
+  void Start()
+  {
+    Cursor.lockState = CursorLockMode.Locked;
+    Cursor.visible = false;
 
-        cam = GetComponentInChildren<Camera>();
-    }
+    cam = GetComponentInChildren<Camera>();
+  }
 
-    private float yRotation; // horizontal
-    private float xRotation; // vertical
+  private float yRotation; // horizontal
+  private float xRotation; // vertical
 
-    // update is called once per frame
-    void Update()
-    {
-        transform.position = cameraPosition.position;
+  // update is called once per frame
+  void Update()
+  {
+    transform.position = cameraPosition.position;
 
-        float mouseX = Input.GetAxis("Mouse X") * Time.fixedDeltaTime * sensitivity;
-        float mouseY = Input.GetAxis("Mouse Y") * Time.fixedDeltaTime * sensitivity;
+    float mouseX = Input.GetAxis("Mouse X") * Time.fixedDeltaTime * sensitivity;
+    float mouseY = Input.GetAxis("Mouse Y") * Time.fixedDeltaTime * sensitivity;
 
-        yRotation += mouseX;
-        xRotation -= mouseY;
-        xRotation = Mathf.Clamp(xRotation, -90f, 90f);
+    yRotation += mouseX;
+    xRotation -= mouseY;
+    xRotation = Mathf.Clamp(xRotation, -90f, 90f);
 
-        cam.transform.eulerAngles = new Vector3(xRotation, yRotation, 0f);
-        orientation.eulerAngles = new Vector3(0f, yRotation, 0f);
-    }
+    cam.transform.eulerAngles = new Vector3(xRotation, yRotation, 0f);
+    orientation.eulerAngles = new Vector3(0f, yRotation, 0f);
+  }
 }

--- a/Assets/Scripts/CameraHandler.cs
+++ b/Assets/Scripts/CameraHandler.cs
@@ -7,6 +7,7 @@ public class CameraHandler : MonoBehaviour
   [Header("Camera")]
   public Camera cam;
   public Transform orientation;
+  public Transform yOrientation;
   public float sensitivity = 100f;
 
   // Start is called before the first frame update
@@ -32,6 +33,7 @@ public class CameraHandler : MonoBehaviour
     xRotation = Mathf.Clamp(xRotation, -90f, 90f);
 
     cam.transform.eulerAngles = new Vector3(xRotation, yRotation, 0f);
-    orientation.eulerAngles = new Vector3(0f, yRotation, 0f);
+    orientation.eulerAngles = new Vector3(xRotation, yRotation, 0f);
+    yOrientation.eulerAngles = new Vector3(0f, yRotation, 0f);
   }
 }

--- a/Assets/Scripts/CameraHandler.cs
+++ b/Assets/Scripts/CameraHandler.cs
@@ -6,7 +6,6 @@ public class CameraHandler : MonoBehaviour
 {
   [Header("Camera")]
   public Camera cam;
-  public Transform cameraPosition;
   public Transform orientation;
   public float sensitivity = 100f;
 
@@ -25,8 +24,6 @@ public class CameraHandler : MonoBehaviour
   // update is called once per frame
   void Update()
   {
-    transform.position = cameraPosition.position;
-
     float mouseX = Input.GetAxis("Mouse X") * Time.fixedDeltaTime * sensitivity;
     float mouseY = Input.GetAxis("Mouse Y") * Time.fixedDeltaTime * sensitivity;
 

--- a/Assets/Scripts/Movement.cs
+++ b/Assets/Scripts/Movement.cs
@@ -5,182 +5,209 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-public class Movement : MonoBehaviour {
-    [Header("Player Properties")]
-    public Vector3 playerScale = new Vector3(1, 1, 1);
-    public float playerDrag = 14f;
-    public float crouchDrag = 20f;
-    public float airDrag = 7f;
-    public float dragSmoothMultiplier = 8000f;
-    private Rigidbody rb;
+public class Movement : MonoBehaviour
+{
+  [Header("Player Properties")]
+  public Vector3 playerScale = new Vector3(1, 1, 1);
+  public float playerDrag = 14f;
+  public float crouchDrag = 20f;
+  public float airDrag = 7f;
+  public float dragSmoothMultiplier = 8000f;
+  private Rigidbody rb;
 
-    [Header("Camera")]
-    public Transform orientation;
+  [Header("Camera")]
+  public Transform orientation;
 
-    [Header("Movement")]
-    public Vector3 moveDirection;
-    public float speed;
-    public float moveSpeed = 8000f;
+  [Header("Movement")]
+  public Vector3 moveDirection;
+  public float speed;
+  public float moveSpeed = 8000f;
 
-    public float fallMultiplier = 3000f;
-    public float airMultiplier = 0.52f;
-    public float crouchAirMultiplier = 0.2f;
+  public float fallMultiplier = 3000f;
+  public float airMultiplier = 0.52f;
+  public float crouchAirMultiplier = 0.2f;
 
-    [Header("Jump")]
-    public float jumpForce = 1000f;
-    public float crouchJumpMultiplier = 0.65f;
+  [Header("Jump")]
+  public float jumpForce = 1000f;
+  public float crouchJumpMultiplier = 0.65f;
 
-    [Header("Crouch")]
-    public float crouchTopSpeed = 13000f;
-    public float crouchSpeed = 5000f;
+  [Header("Crouch")]
+  public float crouchTopSpeed = 13000f;
+  public float crouchSpeed = 5000f;
 
-    [Header("Others")]
-    public Transform feet;
-    public Vector3 groundCheckBox = new Vector3(0.1f, 0.1f, 0.1f);
-    public LayerMask groundLayer;
+  [Header("Others")]
+  public Transform feet;
+  public Vector3 groundCheckBox = new Vector3(0.1f, 0.1f, 0.1f);
+  public LayerMask groundLayer;
 
-    public bool grounded;
-    public bool jumping;
-    public bool crouching;
+  public bool grounded;
+  public bool jumping;
+  public bool crouching;
 
-    private float horizontalInput, verticalInput;
-    public Vector3 slopeMoveDirection;
-    private Vector3 groundNormal;
+  private float horizontalInput, verticalInput;
+  public Vector3 slopeMoveDirection;
+  private Vector3 groundNormal;
 
-    // s tart is called before the first frame update
-    void Start() {
-        rb = GetComponentInChildren<Rigidbody>();
-        rb.freezeRotation = true;
+  // s tart is called before the first frame update
+  void Start()
+  {
+    rb = GetComponentInChildren<Rigidbody>();
+    rb.freezeRotation = true;
 
-        speed = moveSpeed;
+    speed = moveSpeed;
+  }
+
+  // update is called once per frame
+  void Update()
+  {
+    HandleInput();
+    HandleSpeedAndDrag();
+    HandleSlopes();
+
+    grounded = Physics.CheckBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down), groundLayer);
+    AdvancedGizmosVisualizer.DisplayBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down)); // draw gizmos for ground check
+  }
+
+  void FixedUpdate()
+  {
+    HandleMovement();
+  }
+
+  void HandleInput()
+  {
+    horizontalInput = Input.GetAxisRaw("Horizontal");
+    verticalInput = Input.GetAxisRaw("Vertical");
+
+    moveDirection = orientation.forward * verticalInput + orientation.right * horizontalInput;
+    slopeMoveDirection = Vector3.ProjectOnPlane(moveDirection, groundNormal);
+
+    // handle jumping
+    jumping = Input.GetKey(KeyCode.Space);
+
+    if (Input.GetKeyDown(KeyCode.Space) && grounded)
+      Jump();
+
+    // handle crouching
+    crouching = Input.GetKey(KeyCode.LeftShift);
+
+    if (Input.GetKeyDown(KeyCode.LeftShift))
+    {
+      StartCrouch();
+    }
+    if (Input.GetKeyUp(KeyCode.LeftShift))
+    {
+      StopCrouch();
     }
 
-    // update is called once per frame
-    void Update() {
-        HandleInput();
-        HandleSpeedAndDrag();
-        HandleSlopes();
+    if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKey(KeyCode.R))
+      rb.position = new Vector3(0, 1, 0);
+  }
 
-        grounded = Physics.CheckBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down), groundLayer);
-        AdvancedGizmosVisualizer.DisplayBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down)); // draw gizmos for ground check
+  void HandleMovement()
+  {
+    if (rb.velocity.y < 0 || GetSlopeMovementDirection() < 0)
+      rb.AddForce(Vector3.down * fallMultiplier * Time.deltaTime);
+
+    if (grounded)
+    {
+      rb.AddForce(slopeMoveDirection * speed * Time.deltaTime);
     }
-
-    void FixedUpdate() {
-        HandleMovement();
+    else if (crouching && !grounded)
+    {
+      rb.AddForce(slopeMoveDirection * speed * crouchAirMultiplier * Time.deltaTime);
     }
-
-    void HandleInput() {
-        horizontalInput = Input.GetAxisRaw("Horizontal");
-        verticalInput = Input.GetAxisRaw("Vertical");
-
-        moveDirection = orientation.forward * verticalInput + orientation.right * horizontalInput;
-        slopeMoveDirection = Vector3.ProjectOnPlane(moveDirection, groundNormal);
-
-        // handle jumping
-        jumping = Input.GetKey(KeyCode.Space);
-
-        if (Input.GetKeyDown(KeyCode.Space) && grounded)
-            Jump();
-
-        // handle crouching
-        crouching = Input.GetKey(KeyCode.LeftShift);
-
-        if (Input.GetKeyDown(KeyCode.LeftShift)) {
-            StartCrouch();
-        }
-        if (Input.GetKeyUp(KeyCode.LeftShift)) {
-            StopCrouch();
-        }
-
-        if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKey(KeyCode.R))
-            rb.position = new Vector3(0, 1, 0);
+    else
+    {
+      rb.AddForce(slopeMoveDirection * speed * airMultiplier * Time.deltaTime);
     }
+  }
 
-    void HandleMovement() {
-        if (rb.velocity.y < 0 || GetSlopeMovementDirection() < 0)
-            rb.AddForce(Vector3.down * fallMultiplier * Time.deltaTime);
-
-        if (grounded) {
-            rb.AddForce(slopeMoveDirection * speed * Time.deltaTime);
-        } else if (crouching && !grounded) {
-            rb.AddForce(slopeMoveDirection * speed * crouchAirMultiplier * Time.deltaTime);
-        } else {
-            rb.AddForce(slopeMoveDirection * speed * airMultiplier * Time.deltaTime);
-        }
+  void HandleSpeedAndDrag()
+  {
+    if (!grounded)
+    {
+      speed = Mathf.MoveTowards(speed, moveSpeed, Time.deltaTime * dragSmoothMultiplier);
+      rb.drag = airDrag;
     }
-
-    void HandleSpeedAndDrag() {
-        if (!grounded) {
-            speed = Mathf.MoveTowards(speed, moveSpeed, Time.deltaTime * dragSmoothMultiplier);
-            rb.drag = airDrag;
-        } else if (crouching) {
-            if (!IsOnSlope())
-                speed = Mathf.MoveTowards(speed, crouchSpeed, Time.deltaTime * dragSmoothMultiplier);
-            else {
-                if (slopeMoveDirection != Vector3.zero && GetSlopeMovementDirection() < 0) // make sure we are sliding down and not up
-                    speed = Mathf.MoveTowards(speed, speed + 1000f, Time.deltaTime * dragSmoothMultiplier);
-                else {
-                    speed = Mathf.MoveTowards(speed, crouchSpeed, Time.deltaTime * dragSmoothMultiplier);
-                }
-            }
-            if (grounded) // if player crouches mid-air, reset the drag once he touches the ground
-                rb.drag = playerDrag;
-        } else {
-            speed = Mathf.MoveTowards(speed, moveSpeed, Time.deltaTime * dragSmoothMultiplier);
-            rb.drag = playerDrag;
-        }
-    }
-
-    void Jump() {
-        if (crouching)
-            rb.AddForce(rb.transform.up * jumpForce * crouchJumpMultiplier * Time.fixedDeltaTime, ForceMode.Impulse);
+    else if (crouching)
+    {
+      if (!IsOnSlope())
+        speed = Mathf.MoveTowards(speed, crouchSpeed, Time.deltaTime * dragSmoothMultiplier);
+      else
+      {
+        if (slopeMoveDirection != Vector3.zero && GetSlopeMovementDirection() < 0) // make sure we are sliding down and not up
+          speed = Mathf.MoveTowards(speed, speed + 1000f, Time.deltaTime * dragSmoothMultiplier);
         else
-            rb.AddForce(rb.transform.up * jumpForce * Time.fixedDeltaTime, ForceMode.Impulse);
+        {
+          speed = Mathf.MoveTowards(speed, crouchSpeed, Time.deltaTime * dragSmoothMultiplier);
+        }
+      }
+      if (grounded) // if player crouches mid-air, reset the drag once he touches the ground
+        rb.drag = playerDrag;
     }
-
-    void StartCrouch() {
-        // this drag implementation has a logic flaw: you can gain momentum in any direction but you should only gain forward momentum
-        //if (rb.drag >= playerDrag)
-        //    rb.drag = playerDrag / 1.5f; // TODO: apply this only if grounded
-
-        if (speed <= moveSpeed && GetSlopeMovementDirection() <= 0) // prevent spamming (not good detection, must be reworked)
-            speed = crouchTopSpeed;
-
-        // another implementation would be this, however for some reason whatever slide force i give
-        // it, it will always slide for the same amount of time
-        //if (rb.velocity.magnitude > 0.5f)
-        //    rb.AddForce(orientation.transform.forward * slideForce, ForceMode.Force);
-
-        transform.localScale = new Vector3(playerScale.x, playerScale.y / 2, playerScale.z);
-        transform.position = new Vector3(transform.position.x, transform.position.y - 0.5f, transform.position.z);
+    else
+    {
+      speed = Mathf.MoveTowards(speed, moveSpeed, Time.deltaTime * dragSmoothMultiplier);
+      rb.drag = playerDrag;
     }
+  }
 
-    void StopCrouch() {
-        transform.localScale = playerScale;
-        transform.position = new Vector3(transform.position.x, transform.position.y + 0.5f, transform.position.z);
-    }
+  void Jump()
+  {
+    if (crouching)
+      rb.AddForce(rb.transform.up * jumpForce * crouchJumpMultiplier * Time.fixedDeltaTime, ForceMode.Impulse);
+    else
+      rb.AddForce(rb.transform.up * jumpForce * Time.fixedDeltaTime, ForceMode.Impulse);
+  }
 
-    private RaycastHit slopeHit;
+  void StartCrouch()
+  {
+    // this drag implementation has a logic flaw: you can gain momentum in any direction but you should only gain forward momentum
+    //if (rb.drag >= playerDrag)
+    //    rb.drag = playerDrag / 1.5f; // TODO: apply this only if grounded
 
-    void HandleSlopes() {
-        Physics.Raycast(feet.position, Vector3.down, out slopeHit, 0.3f);
-        groundNormal = slopeHit.normal;
-        print(groundNormal);
-    }
+    if (speed <= moveSpeed && GetSlopeMovementDirection() <= 0) // prevent spamming (not good detection, must be reworked)
+      speed = crouchTopSpeed;
 
-    bool IsOnSlope() {
-        if (groundNormal != Vector3.up)
-            return true;
-        else
-            return false;
-    }
+    // another implementation would be this, however for some reason whatever slide force i give
+    // it, it will always slide for the same amount of time
+    //if (rb.velocity.magnitude > 0.5f)
+    //    rb.AddForce(orientation.transform.forward * slideForce, ForceMode.Force);
 
-    float GetSlopeMovementDirection() {
-        // calculate the movement direction on the slope
-        Vector3 projectedMovement = Vector3.ProjectOnPlane(moveDirection, groundNormal);
+    transform.localScale = new Vector3(playerScale.x, playerScale.y / 2, playerScale.z);
+    transform.position = new Vector3(transform.position.x, transform.position.y - 0.5f, transform.position.z);
+  }
 
-        // return the dot product between the movement direction and the global up vector
-        return Vector3.Dot(projectedMovement, Vector3.up);
-    }
+  void StopCrouch()
+  {
+    transform.localScale = playerScale;
+    transform.position = new Vector3(transform.position.x, transform.position.y + 0.5f, transform.position.z);
+  }
+
+  private RaycastHit slopeHit;
+
+  void HandleSlopes()
+  {
+    Physics.Raycast(feet.position, Vector3.down, out slopeHit, 0.3f);
+    groundNormal = slopeHit.normal;
+    print(groundNormal);
+  }
+
+  bool IsOnSlope()
+  {
+    if (groundNormal != Vector3.up)
+      return true;
+    else
+      return false;
+  }
+
+  float GetSlopeMovementDirection()
+  {
+    // calculate the movement direction on the slope
+    Vector3 projectedMovement = Vector3.ProjectOnPlane(moveDirection, groundNormal);
+
+    // return the dot product between the movement direction and the global up vector
+    return Vector3.Dot(projectedMovement, Vector3.up);
+  }
 
 }

--- a/Assets/Scripts/Movement.cs
+++ b/Assets/Scripts/Movement.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using TMPro;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -13,6 +14,8 @@ public class Movement : MonoBehaviour
   public float crouchDrag = 20f;
   public float airDrag = 7f;
   public float dragSmoothMultiplier = 8000f;
+
+  public Transform body;
   private Rigidbody rb;
 
   [Header("Camera")]
@@ -32,6 +35,7 @@ public class Movement : MonoBehaviour
   public float crouchJumpMultiplier = 0.65f;
 
   [Header("Crouch")]
+  public Vector3 crouchScale = new Vector3(1, 0.7f, 1);
   public float crouchTopSpeed = 13000f;
   public float crouchSpeed = 5000f;
 
@@ -44,8 +48,6 @@ public class Movement : MonoBehaviour
   public bool jumping;
   public bool crouching;
 
-  public Transform[] objectsToNotGetScaledWhenCrouching;
-
   private float horizontalInput, verticalInput;
   public Vector3 slopeMoveDirection;
   private Vector3 groundNormal;
@@ -53,7 +55,7 @@ public class Movement : MonoBehaviour
   // s tart is called before the first frame update
   void Start()
   {
-    rb = GetComponentInChildren<Rigidbody>();
+    rb = GetComponent<Rigidbody>();
     rb.freezeRotation = true;
 
     speed = moveSpeed;
@@ -68,6 +70,11 @@ public class Movement : MonoBehaviour
 
     grounded = Physics.CheckBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down), groundLayer);
     AdvancedGizmosVisualizer.DisplayBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down)); // draw gizmos for ground check
+
+  }
+
+  void LateUpdate()
+  {
   }
 
   void FixedUpdate()
@@ -102,7 +109,7 @@ public class Movement : MonoBehaviour
     }
 
     if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKey(KeyCode.R))
-      rb.position = new Vector3(0, 1, 0);
+      transform.position = new Vector3(0, 1, 0);
   }
 
   void HandleMovement()
@@ -176,23 +183,15 @@ public class Movement : MonoBehaviour
     //if (rb.velocity.magnitude > 0.5f)
     //    rb.AddForce(orientation.transform.forward * slideForce, ForceMode.Force);
 
-    transform.localScale = new Vector3(playerScale.x, playerScale.y / 2, playerScale.z);
-    for (int i = 0; i < objectsToNotGetScaledWhenCrouching.Length; i++)
-    {
-      objectsToNotGetScaledWhenCrouching[i].localScale = new Vector3(objectsToNotGetScaledWhenCrouching[i].localScale.x, objectsToNotGetScaledWhenCrouching[i].localScale.y * 2, objectsToNotGetScaledWhenCrouching[i].localScale.z);
-    }
-    transform.position = new Vector3(transform.position.x, transform.position.y - 0.5f, transform.position.z);
+    body.localScale = crouchScale;
+    transform.position = new Vector3(transform.position.x, transform.position.y - (playerScale.y - crouchScale.y), transform.position.z);
 
   }
 
   void StopCrouch()
   {
-    transform.localScale = playerScale;
-    for (int i = 0; i < objectsToNotGetScaledWhenCrouching.Length; i++)
-    {
-      objectsToNotGetScaledWhenCrouching[i].localScale = new Vector3(objectsToNotGetScaledWhenCrouching[i].localScale.x, objectsToNotGetScaledWhenCrouching[i].localScale.y / 2, objectsToNotGetScaledWhenCrouching[i].localScale.z);
-    }
-    transform.position = new Vector3(transform.position.x, transform.position.y + 0.5f, transform.position.z);
+    body.localScale = playerScale;
+    transform.position = new Vector3(transform.position.x, transform.position.y + (playerScale.y - crouchScale.y), transform.position.z);
   }
 
   private RaycastHit slopeHit;

--- a/Assets/Scripts/Movement.cs
+++ b/Assets/Scripts/Movement.cs
@@ -21,6 +21,8 @@ public class Movement : MonoBehaviour
   [Header("Camera")]
   public Transform orientation;
 
+  public Transform yOrientation;
+
   [Header("Movement")]
   public Vector3 moveDirection;
   public float speed;
@@ -70,7 +72,6 @@ public class Movement : MonoBehaviour
 
     grounded = Physics.CheckBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down), groundLayer);
     AdvancedGizmosVisualizer.DisplayBox(feet.position, groundCheckBox, Quaternion.Euler(Vector3.down)); // draw gizmos for ground check
-
   }
 
   void LateUpdate()
@@ -87,7 +88,7 @@ public class Movement : MonoBehaviour
     horizontalInput = Input.GetAxisRaw("Horizontal");
     verticalInput = Input.GetAxisRaw("Vertical");
 
-    moveDirection = orientation.forward * verticalInput + orientation.right * horizontalInput;
+    moveDirection = yOrientation.forward * verticalInput + yOrientation.right * horizontalInput;
     slopeMoveDirection = Vector3.ProjectOnPlane(moveDirection, groundNormal);
 
     // handle jumping

--- a/Assets/Scripts/Movement.cs
+++ b/Assets/Scripts/Movement.cs
@@ -44,6 +44,8 @@ public class Movement : MonoBehaviour
   public bool jumping;
   public bool crouching;
 
+  public Transform[] objectsToNotGetScaledWhenCrouching;
+
   private float horizontalInput, verticalInput;
   public Vector3 slopeMoveDirection;
   private Vector3 groundNormal;
@@ -175,12 +177,21 @@ public class Movement : MonoBehaviour
     //    rb.AddForce(orientation.transform.forward * slideForce, ForceMode.Force);
 
     transform.localScale = new Vector3(playerScale.x, playerScale.y / 2, playerScale.z);
+    for (int i = 0; i < objectsToNotGetScaledWhenCrouching.Length; i++)
+    {
+      objectsToNotGetScaledWhenCrouching[i].localScale = new Vector3(objectsToNotGetScaledWhenCrouching[i].localScale.x, objectsToNotGetScaledWhenCrouching[i].localScale.y * 2, objectsToNotGetScaledWhenCrouching[i].localScale.z);
+    }
     transform.position = new Vector3(transform.position.x, transform.position.y - 0.5f, transform.position.z);
+
   }
 
   void StopCrouch()
   {
     transform.localScale = playerScale;
+    for (int i = 0; i < objectsToNotGetScaledWhenCrouching.Length; i++)
+    {
+      objectsToNotGetScaledWhenCrouching[i].localScale = new Vector3(objectsToNotGetScaledWhenCrouching[i].localScale.x, objectsToNotGetScaledWhenCrouching[i].localScale.y / 2, objectsToNotGetScaledWhenCrouching[i].localScale.z);
+    }
     transform.position = new Vector3(transform.position.x, transform.position.y + 0.5f, transform.position.z);
   }
 

--- a/Assets/Scripts/PositionSyncer.cs
+++ b/Assets/Scripts/PositionSyncer.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PositionSyncer : MonoBehaviour
+{
+  public Transform cam;
+  public Transform cameraPosition;
+  public Transform orientation;
+  public Transform orientationPosition;
+  public Transform feet;
+  public Transform feetPosition;
+
+  // Start is called before the first frame update
+  void Start()
+  {
+
+  }
+
+  // Update is called once per frame
+  void Update()
+  {
+    cam.position = cameraPosition.position;
+    orientation.position = orientationPosition.position;
+    feet.position = feetPosition.position;
+  }
+}

--- a/Assets/Scripts/PositionSyncer.cs
+++ b/Assets/Scripts/PositionSyncer.cs
@@ -7,6 +7,7 @@ public class PositionSyncer : MonoBehaviour
   public Transform cam;
   public Transform cameraPosition;
   public Transform orientation;
+  public Transform yOrientation;
   public Transform orientationPosition;
   public Transform feet;
   public Transform feetPosition;
@@ -22,6 +23,7 @@ public class PositionSyncer : MonoBehaviour
   {
     cam.position = cameraPosition.position;
     orientation.position = orientationPosition.position;
+    yOrientation.position = orientationPosition.position;
     feet.position = feetPosition.position;
   }
 }

--- a/Assets/Scripts/PositionSyncer.cs.meta
+++ b/Assets/Scripts/PositionSyncer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fe11ebc6784b938fab7770fff3e297f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WeaponSway.cs
+++ b/Assets/Scripts/WeaponSway.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WeaponSway : MonoBehaviour
+{
+  [Header("Sway Settings")]
+  [SerializeField] private float smooth;
+  [SerializeField] private float swayMultiplier;
+
+  void Start()
+  {
+  }
+
+  void Update()
+  {
+    float mouseX = Input.GetAxisRaw("Mouse X") * swayMultiplier;
+    float mouseY = Input.GetAxisRaw("Mouse Y") * swayMultiplier + 30f;
+
+    Quaternion rotationX = Quaternion.AngleAxis(-mouseY, Vector3.right);
+    Quaternion rotationY = Quaternion.AngleAxis(mouseX, Vector3.up);
+
+    Quaternion targetRotation = rotationX * rotationY;
+
+    transform.localRotation = Quaternion.Slerp(transform.localRotation, targetRotation, smooth * Time.deltaTime);
+  }
+}

--- a/Assets/Scripts/WeaponSway.cs
+++ b/Assets/Scripts/WeaponSway.cs
@@ -15,7 +15,7 @@ public class WeaponSway : MonoBehaviour
   void Update()
   {
     float mouseX = Input.GetAxisRaw("Mouse X") * swayMultiplier;
-    float mouseY = Input.GetAxisRaw("Mouse Y") * swayMultiplier + 30f;
+    float mouseY = Input.GetAxisRaw("Mouse Y") * swayMultiplier;
 
     Quaternion rotationX = Quaternion.AngleAxis(-mouseY, Vector3.right);
     Quaternion rotationY = Quaternion.AngleAxis(mouseX, Vector3.up);

--- a/Assets/Scripts/WeaponSway.cs.meta
+++ b/Assets/Scripts/WeaponSway.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20a0025fffa0bbfe8b7403e7b03b9d63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Thirdparty.meta
+++ b/Assets/Thirdparty.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a932d0d24d36f7b4aaa8ad6fbd0c750e
+guid: 6dce8d356ce6054bc936b5ffcd871272
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.feature.development": "1.0.1",
     "com.unity.textmeshpro": "3.0.7",
     "com.unity.timeline": "1.7.6",
+    "com.unity.toolchain.linux-x86_64": "2.0.10",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.9.4",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -81,6 +81,22 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "2.0.10",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.9",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.33",
       "depth": 1,
@@ -116,10 +132,20 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "2.0.10",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10",
+        "com.unity.sysroot.linux-x86_64": "2.0.9"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
- migrated to linux/vscode
- gave the player a katana
- reorganized the hierarchy of the player object
  - this fixed child objects of  the player object getting scaled down as well when crouching
  - katana will now stay relative to the camera without being a child of the camera
  - added a yOrientation object to keep track of the orientation without the x axis
- added sway to katana